### PR TITLE
Fix CI testing

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -31,8 +31,8 @@ jobs:
         channels: conda-forge,defaults
 
         activate-environment: test
-        auto-update-conda: true
-        auto-activate-base: false
+        auto-update-conda: false
+        auto-activate-base: true
         show-channel-urls: true
 
     - name: Install package

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -29,8 +29,9 @@ jobs:
         miniconda-version: "latest"
         environment-file: test_env.yaml
 
-        activate-environment: test
-        auto-update-conda: false
+        auto-update-conda: true
+        auto-activate-base: true
+        activate-environment: testEnv
         show-channel-urls: true
 
     - name: Install package

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -23,16 +23,15 @@ jobs:
         df -h
         ulimit -a
     # More info on options: https://github.com/conda-incubator/setup-miniconda
-    - uses: conda-incubator/setup-miniconda@v2
+    - uses: conda-incubator/setup-miniconda@v3
       with:
         python-version: ${{ matrix.python-version }}
+        miniconda-version: "latest"
         environment-file: test_env.yaml
 
         channels: conda-forge,defaults
-
         activate-environment: test
         auto-update-conda: false
-        auto-activate-base: true
         show-channel-urls: true
 
     - name: Install package

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -29,7 +29,6 @@ jobs:
         miniconda-version: "latest"
         environment-file: test_env.yaml
 
-        channels: conda-forge,defaults
         activate-environment: test
         auto-update-conda: false
         show-channel-urls: true

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -29,8 +29,8 @@ jobs:
         miniconda-version: "latest"
         environment-file: test_env.yaml
 
-        auto-update-conda: true
-        auto-activate-base: true
+        auto-update-conda: false
+        auto-activate-base: false
         activate-environment: testEnv
         show-channel-urls: true
 

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -1,14 +1,8 @@
 name: CI_pytest
 
 on:
-  push:
-    branches:
-      - "master"
-      - "main"
-  pull_request:
-    branches:
-      - "master"
-      - "main"
+  - push
+  - pull_request
 
 jobs:
   test:
@@ -37,7 +31,7 @@ jobs:
         channels: conda-forge,defaults
 
         activate-environment: test
-        auto-update-conda: false
+        auto-update-conda: true
         auto-activate-base: false
         show-channel-urls: true
 

--- a/pyvibdmc/pyvibdmc.py
+++ b/pyvibdmc/pyvibdmc.py
@@ -864,12 +864,12 @@ class DMC_Sim:
                 setattr(res, k, copy.deepcopy(v, memodict))
         return res
 
-
-def dmc_restart(potential, chkpt_folder, sim_name, additional_timesteps=0, impsamp=None, imp_samp_oned=False):
+def dmc_restart(potential, chkpt_folder, sim_name, additional_timesteps=0, impsamp=None, imp_samp_oned=False, fixed_node=None):
     """TODO: Need to add in impsamp infrastructure here for restarting..."""
     dmc_sim = SimArchivist.reload_sim(chkpt_folder, sim_name)
     # Update simulation parameters based on additional timesteps
     dmc_sim.imp1d = imp_samp_oned
+    dmc_sim.fixed_node = fixed_node
     dmc_sim._init_restart(additional_timesteps, impsamp)
     # Re-initialize the potential and the logger, as those are not pickleable
     dmc_sim.potential = potential.getpot

--- a/pyvibdmc/simulation_utilities/tensorflow_descriptors/distance_descriptors.py
+++ b/pyvibdmc/simulation_utilities/tensorflow_descriptors/distance_descriptors.py
@@ -56,7 +56,7 @@ class DistIt:
 
         # Just check if all atoms are included in the sorted things
         if self.sorted_atoms is not None:
-            flat_like = self.xp.concatenate(self.xp.asarray(self.sorted_atoms)).ravel()
+            flat_like = self.xp.concatenate(self.xp.asarray(self.sorted_atoms, dtype="object")).ravel()
             if len(flat_like) != self.num_atoms:
                 raise ValueError("Please put all atoms in sorted_atoms list")
 

--- a/pyvibdmc/tests/test_analysis.py
+++ b/pyvibdmc/tests/test_analysis.py
@@ -85,19 +85,19 @@ def test_dihedral():
     analyzer_dim = pv.AnalyzeWfn(dimie)
     # dim_nums = [3,1,4,5]
     angle = np.degrees(analyzer_dim.dihedral(3 - 1, 1 - 1, 4 - 1, 5 - 1))
-    assert pytest.approx(angle, 122.56)
+    assert pytest.approx(angle) == 122.56
 
     angle2 = np.degrees(analyzer_dim.dihedral(3 - 1, 1 - 1, 4 - 1, 6 - 1))
-    assert pytest.approx(angle2, -123.14)
+    assert pytest.approx(angle2) == -123.14
 
     # Improper Dihedral
     analyzer_form = pv.AnalyzeWfn(formie)
 
     # form_nums = [3,1,4,2]
     improp = np.degrees(analyzer_form.dihedral(3 - 1, 1 - 1, 4 - 1, 2 - 1))
-    assert pytest.approx(improp, 177)
+    assert pytest.approx(improp) == 177
     improp2 = np.degrees(analyzer_form.dihedral(2 - 1, 1 - 1, 4 - 1, 3 - 1))
-    assert pytest.approx(improp2, -177)
+    assert pytest.approx(improp2) ==-177
 
 
 # Plotting and analyzing tests

--- a/pyvibdmc/tests/test_analysis.py
+++ b/pyvibdmc/tests/test_analysis.py
@@ -85,10 +85,10 @@ def test_dihedral():
     analyzer_dim = pv.AnalyzeWfn(dimie)
     # dim_nums = [3,1,4,5]
     angle = np.degrees(analyzer_dim.dihedral(3 - 1, 1 - 1, 4 - 1, 5 - 1))
-    assert pytest.approx(angle, abs=1e-1) == 122.56
+    assert pytest.approx(angle, abs=1e-1) == 122.6
 
     angle2 = np.degrees(analyzer_dim.dihedral(3 - 1, 1 - 1, 4 - 1, 6 - 1))
-    assert pytest.approx(angle2, abs=1e-1) == -123.14
+    assert pytest.approx(angle2, abs=1e-1) == -123.1
 
     # Improper Dihedral
     analyzer_form = pv.AnalyzeWfn(formie)

--- a/pyvibdmc/tests/test_analysis.py
+++ b/pyvibdmc/tests/test_analysis.py
@@ -85,19 +85,19 @@ def test_dihedral():
     analyzer_dim = pv.AnalyzeWfn(dimie)
     # dim_nums = [3,1,4,5]
     angle = np.degrees(analyzer_dim.dihedral(3 - 1, 1 - 1, 4 - 1, 5 - 1))
-    assert pytest.approx(angle) == 122.56
+    assert pytest.approx(angle, abs=1e-1) == 122.56
 
     angle2 = np.degrees(analyzer_dim.dihedral(3 - 1, 1 - 1, 4 - 1, 6 - 1))
-    assert pytest.approx(angle2) == -123.14
+    assert pytest.approx(angle2, abs=1e-1) == -123.14
 
     # Improper Dihedral
     analyzer_form = pv.AnalyzeWfn(formie)
 
     # form_nums = [3,1,4,2]
     improp = np.degrees(analyzer_form.dihedral(3 - 1, 1 - 1, 4 - 1, 2 - 1))
-    assert pytest.approx(improp) == 177
+    assert pytest.approx(improp, abs=1) == 177
     improp2 = np.degrees(analyzer_form.dihedral(2 - 1, 1 - 1, 4 - 1, 3 - 1))
-    assert pytest.approx(improp2) ==-177
+    assert pytest.approx(improp2, , abs=1) ==-177
 
 
 # Plotting and analyzing tests

--- a/pyvibdmc/tests/test_analysis.py
+++ b/pyvibdmc/tests/test_analysis.py
@@ -97,7 +97,7 @@ def test_dihedral():
     improp = np.degrees(analyzer_form.dihedral(3 - 1, 1 - 1, 4 - 1, 2 - 1))
     assert pytest.approx(improp, abs=1) == 177
     improp2 = np.degrees(analyzer_form.dihedral(2 - 1, 1 - 1, 4 - 1, 3 - 1))
-    assert pytest.approx(improp2, , abs=1) ==-177
+    assert pytest.approx(improp2, abs=1) ==-177
 
 
 # Plotting and analyzing tests

--- a/pyvibdmc/tests/test_pot.py
+++ b/pyvibdmc/tests/test_pot.py
@@ -66,7 +66,6 @@ def test_no_mp_pot():
 def test_nn_pot():
     from ..simulation_utilities.tensorflow_descriptors.distance_descriptors import DistIt
     import tensorflow as tf
-    from tensorflow.keras.legacy.saving import legacy_h5_format
 
     # initialize potential
     potDir = os.path.join(os.path.dirname(__file__),
@@ -78,8 +77,7 @@ def test_nn_pot():
     pot_dict = {'descriptor': coulomb,
                 'batch_size': 100}
     model_path = f'{potDir}/sample_h4o2_nn.h5'
-    # model = tf.keras.models.load_model(model_path)
-    model = legacy_h5_format.load_model_from_hdf5(model_path, custom_objects={'mse': 'mse'})
+    model = tf.keras.models.load_model(model_path, custom_objects={'mse': 'mse'})
 
     harm_pot = pv.NN_Potential(potential_function=potFunc,
                                python_file=pyFile,

--- a/pyvibdmc/tests/test_pot.py
+++ b/pyvibdmc/tests/test_pot.py
@@ -66,6 +66,7 @@ def test_no_mp_pot():
 def test_nn_pot():
     from ..simulation_utilities.tensorflow_descriptors.distance_descriptors import DistIt
     import tensorflow as tf
+    from tensorflow.keras.src.legacy.saving import legacy_h5_format
 
     # initialize potential
     potDir = os.path.join(os.path.dirname(__file__),
@@ -77,7 +78,6 @@ def test_nn_pot():
     pot_dict = {'descriptor': coulomb,
                 'batch_size': 100}
     model_path = f'{potDir}/sample_h4o2_nn.h5'
-    from tf.keras.src.legacy.saving import legacy_h5_format
     # model = tf.keras.models.load_model(model_path)
     model = legacy_h5_format.load_model_from_hdf5(model_path, custom_objects={'mse': 'mse'})
 

--- a/pyvibdmc/tests/test_pot.py
+++ b/pyvibdmc/tests/test_pot.py
@@ -66,7 +66,7 @@ def test_no_mp_pot():
 def test_nn_pot():
     from ..simulation_utilities.tensorflow_descriptors.distance_descriptors import DistIt
     import tensorflow as tf
-    from tensorflow.keras.src.legacy.saving import legacy_h5_format
+    from tensorflow.keras.legacy.saving import legacy_h5_format
 
     # initialize potential
     potDir = os.path.join(os.path.dirname(__file__),

--- a/pyvibdmc/tests/test_pot.py
+++ b/pyvibdmc/tests/test_pot.py
@@ -77,7 +77,10 @@ def test_nn_pot():
     pot_dict = {'descriptor': coulomb,
                 'batch_size': 100}
     model_path = f'{potDir}/sample_h4o2_nn.h5'
-    model = tf.keras.models.load_model(model_path)
+    from tf.keras.src.legacy.saving import legacy_h5_format
+    # model = tf.keras.models.load_model(model_path)
+    model = legacy_h5_format.load_model_from_hdf5(model_path, custom_objects={'mse': 'mse'})
+
     harm_pot = pv.NN_Potential(potential_function=potFunc,
                                python_file=pyFile,
                                potential_directory=potDir,

--- a/test_env.yaml
+++ b/test_env.yaml
@@ -1,5 +1,7 @@
-name: test
+name: testEnv
 channels:
+  - conda-forge
+  - defaults
 dependencies:
     # Package dependencies
   - numpy

--- a/test_env.yaml
+++ b/test_env.yaml
@@ -7,7 +7,6 @@ dependencies:
   - matplotlib
   - tensorflow
   - mpi4py
-    # Testing
   - pytest
   - pytest-cov
   - codecov


### PR DESCRIPTION
## Description

There were a few things that I needed to update in our tests to make them compatible with the latest versions being pulled in via the conda env yaml file. Since these deps aren't versioned, we expect them to break after a while. I think that we should have versioning on them, but that's out of scope for this PR. 

Change conda environment from test to testEnv seems to have fixed the odd GHA failure that said
> Error: No installed conda 'base' environment found at !If you are using this action in a self-hosted runner that already provides its own Miniconda installation, please specify its location with a `CONDA` environment variable. If you want us to download and install Miniconda or Miniforge for you, add `miniconda-version: "latest"` or `miniforge-version: "latest"`, respectively, to the parameters for this action.

