### PR TITLE
Updated CI/CD script to specify usage of python 3.11

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: "3.x"
+        python-version: "3.11"
     - name: Install pypa/build
       run: >-
         python3 -m


### PR DESCRIPTION
to avoid SafeConfigParser depreciation issue, to master branch instead of dev.